### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/client_review_upload.py
+++ b/client_review_upload.py
@@ -19,7 +19,7 @@ class Thread(threading.Thread):
     def run(self):
 
         ftrack.Review.makeReviewable(self.version, self.path)
-        print 'uploaded: %s' % self.path
+        print 'uploaded: {0!s}'.format(self.path)
         self.version.publish()
 
 def callback(event):

--- a/hobsoft_ingest.py
+++ b/hobsoft_ingest.py
@@ -34,7 +34,7 @@ def callback(event):
                 status = utils.GetStatusByName('ready')
                 task = shot.createTask('painting', taskType=task_type,
                                         taskStatus=status)
-            print 'hobsoft ingest on %s' % task
+            print 'hobsoft ingest on {0!s}'.format(task)
 
 
 # Subscribe to events with the update topic.

--- a/hobsoft_sync.py
+++ b/hobsoft_sync.py
@@ -85,7 +85,7 @@ def callback(event):
 
             sequence_name = task.getParent().getParent().getName()
             shot_name = 'c' + task.getParent().getName().split('c')[1]
-            filename = '%s%s.compositing.####.dpx' % (sequence_name,
+            filename = '{0!s}{1!s}.compositing.####.dpx'.format(sequence_name,
                                                                     shot_name)
             dst = os.path.join('B:\\', 'film', sequence_name, shot_name,
                                             'current', 'compositing', filename.upper())
@@ -107,12 +107,12 @@ def callback(event):
 
             path = task.getParent().getName() + '/'
             path += version.getAsset().getName() + ' '
-            path += 'v%s' % str(version.getVersion()).zfill(2)
+            path += 'v{0!s}'.format(str(version.getVersion()).zfill(2))
 
             # job data
             data = 'UserName=render.farm\n'
-            data += 'Name=%s Transcoding\n' % path
-            data += 'Frames=%s-%s\n' % (frame_start, frame_end)
+            data += 'Name={0!s} Transcoding\n'.format(path)
+            data += 'Frames={0!s}-{1!s}\n'.format(frame_start, frame_end)
             data += 'Group=draft\n'
             data += 'Pool=medium\n'
             data += 'Plugin=Draft\n'
@@ -127,10 +127,10 @@ def callback(event):
                 outfile.write(data)
 
             # plugin data
-            data = 'scriptFile=%s\n' % script
-            data += 'ScriptArg0=frameList=%s-%s\n' % (frame_start, frame_end)
-            data += 'ScriptArg1=outFile=%s\n' % dst
-            data += 'ScriptArg2=inFile=%s\n' % src
+            data = 'scriptFile={0!s}\n'.format(script)
+            data += 'ScriptArg0=frameList={0!s}-{1!s}\n'.format(frame_start, frame_end)
+            data += 'ScriptArg1=outFile={0!s}\n'.format(dst)
+            data += 'ScriptArg2=inFile={0!s}\n'.format(src)
 
             current_dir = tempfile.gettempdir()
             filename = 'plugin.txt'

--- a/supervisor_review_status.py
+++ b/supervisor_review_status.py
@@ -48,8 +48,8 @@ def callback(event):
 
                     path = task.getParent().getName() + '/'
                     path += version_latest.getAsset().getName() + ' '
-                    path += 'v%s' % str(version_latest.getVersion()).zfill(2)
-                    print 'Setting %s "img" to "Supervisor Review"' % path
+                    path += 'v{0!s}'.format(str(version_latest.getVersion()).zfill(2))
+                    print 'Setting {0!s} "img" to "Supervisor Review"'.format(path)
 
                 # setting movie
                 version_number = 0
@@ -66,8 +66,8 @@ def callback(event):
 
                     path = task.getParent().getName() + '/'
                     path += version_latest.getAsset().getName() + ' '
-                    path += 'v%s' % str(version_latest.getVersion()).zfill(2)
-                    print 'Setting %s "mov" to "Supervisor Review"' % path
+                    path += 'v{0!s}'.format(str(version_latest.getVersion()).zfill(2))
+                    print 'Setting {0!s} "mov" to "Supervisor Review"'.format(path)
 
 
 # Subscribe to events with the update topic.

--- a/task_thumbnail.py
+++ b/task_thumbnail.py
@@ -23,7 +23,7 @@ def callback(event):
             parent = task.getParent()
             if parent.get('thumbid') and not task.get('thumbid'):
                 task.set('thumbid', value=parent.get('thumbid'))
-                print 'Updated thumbnail on %s/%s' % (parent.getName(),
+                print 'Updated thumbnail on {0!s}/{1!s}'.format(parent.getName(),
                                                         task.getName())
 
 

--- a/version_to_task_statuses.py
+++ b/version_to_task_statuses.py
@@ -42,9 +42,9 @@ def callback(event):
                 try:
                     task.setStatus(task_status)
                 except Exception as e:
-                    print '%s status couldnt be set: %s' % (path, e)
+                    print '{0!s} status couldnt be set: {1!s}'.format(path, e)
                 else:
-                    print '%s updated to "%s"' % (path, task_status.get('name'))
+                    print '{0!s} updated to "{1!s}"'.format(path, task_status.get('name'))
 
 
 # Subscribe to events with the update topic.

--- a/version_up.py
+++ b/version_up.py
@@ -45,7 +45,7 @@ def version_set(string, prefix, oldintval, newintval):
   # Replace all version strings with matching numbers
   for match in matches:
     # use expression instead of expr so 0 prefix does not make octal
-    fmt = "%%(#)0%dd" % (len(match) - 2)
+    fmt = "%(#)0{0:d}d".format((len(match) - 2))
     newfullvalue = match[0] + prefix + str(fmt % {"#": newintval})
     string = re.sub(match, newfullvalue, string)
   return string
@@ -62,7 +62,7 @@ def version_up(path):
         os.makedirs(os.path.dirname(new_path))
 
     if not os.path.exists(new_path):
-        print 'Copying: %s' % path
+        print 'Copying: {0!s}'.format(path)
         shutil.copy(path, new_path)
 
     (prefix, v) = version_get(path, 'v')
@@ -153,7 +153,7 @@ def callback(event):
                                         version_string = 'v' + str(new_version_number).zfill(3)
                                         new_name = version_string.join(new_path.split(version_string)[:-1]) + version_string + extension
                                         os.rename(new_path, new_name)
-                                        print 'Renaming to %s' % new_name
+                                        print 'Renaming to {0!s}'.format(new_name)
                                     else:
                                         [new_path, new_version_number] = version_up(path)
 
@@ -161,8 +161,8 @@ def callback(event):
                                     for p in task.getParents():
                                         path = p.get('name') + '/' + path
 
-                                    msg = "Version from %s" % int(version_number)
-                                    msg += " to %s on %s" % (int(new_version_number), path)
+                                    msg = "Version from {0!s}".format(int(version_number))
+                                    msg += " to {0!s} on {1!s}".format(int(new_version_number), path)
                                     print msg
                 except:
                     print traceback.format_exc()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:tokejepsen:ftrack-event-plugins?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:tokejepsen:ftrack-event-plugins?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
